### PR TITLE
Link to emcee.agency website (Fix #3)

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
         <div class="row">
           <div class="col-12">
             <p>Code &amp; docs licensed under <a href="">MIT</a> license.</p>
-            <p>Copyright &copy; 2017 10244872 Canada Inc.</p>
+            <p>Copyright &copy; 2017 <a href="https://emcee.agency">10244872 Canada Inc.</a></p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Changes
Added `<a>` tag to the business name in the footer.
Now points to the `emcee.agency` website
# Issue
See #3 
